### PR TITLE
FIX np.float32 json dump and split single error

### DIFF
--- a/generate_ahap.py
+++ b/generate_ahap.py
@@ -50,6 +50,8 @@ def convert_wav_to_ahap(input_wav, output_dir, mode, split):
         else:
             splits = ['bass', 'vocals', 'drums', 'other']
             for split_type in splits:
+                if split != "all" and split != split_type:
+                    continue
                 ahap_data = generate_ahap(audio_data, sample_rate, mode, harmonic, percussive, bass, duration, split_type)
                 output_ahap = os.path.join(output_dir, os.path.basename(input_wav).replace('.wav', f'_{split_type}.ahap'))
                 write_ahap_file(output_ahap, ahap_data)
@@ -112,8 +114,8 @@ def create_event(event_type, time, audio_data, sample_rate, split):
             "Time": float(time),
             "EventType": event_type,
             "EventParameters": [
-                {"ParameterID": "HapticIntensity", "ParameterValue": intensity},
-                {"ParameterID": "HapticSharpness", "ParameterValue": sharpness}
+                {"ParameterID": "HapticIntensity", "ParameterValue": float(intensity)},
+                {"ParameterID": "HapticSharpness", "ParameterValue": float(sharpness)}
             ]
         }
     }
@@ -241,8 +243,8 @@ def add_continuous_events(pattern, audio_data, sample_rate, harmonic, bass, dura
                     "EventType": "HapticContinuous",
                     "EventDuration": time_step,
                     "EventParameters": [
-                        {"ParameterID": "HapticIntensity", "ParameterValue": intensity},
-                        {"ParameterID": "HapticSharpness", "ParameterValue": sharpness}
+                        {"ParameterID": "HapticIntensity", "ParameterValue": float(intensity)},
+                        {"ParameterID": "HapticSharpness", "ParameterValue": float(sharpness)}
                     ]
                 }
             }

--- a/generate_ahap.py
+++ b/generate_ahap.py
@@ -13,7 +13,7 @@ def convert_wav_to_ahap(input_wav, output_dir, mode, split):
         start_time = time.time()
 
         # Load audio file using pydub
-        audio = AudioSegment.from_file(input_wav, format="wav")
+        audio = AudioSegment.from_file(input_wav, format=os.path.splitext(input_wav)[-1][1:])
 
         # Convert to mono and set sample rate to 44.1 kHz
         audio = audio.set_channels(1).set_frame_rate(44100)
@@ -44,7 +44,7 @@ def convert_wav_to_ahap(input_wav, output_dir, mode, split):
 
         if split == "none":
             ahap_data = generate_ahap(audio_data, sample_rate, mode, harmonic, percussive, bass, duration, split)
-            output_ahap = os.path.join(output_dir, os.path.basename(input_wav).replace('.wav', '_combined.ahap'))
+            output_ahap = os.path.join(output_dir, os.path.basename(input_wav).replace(os.path.splitext(input_wav)[-1], '_combined.ahap'))
             write_ahap_file(output_ahap, ahap_data)
             output_files.append(output_ahap)
         else:
@@ -53,7 +53,7 @@ def convert_wav_to_ahap(input_wav, output_dir, mode, split):
                 if split != "all" and split != split_type:
                     continue
                 ahap_data = generate_ahap(audio_data, sample_rate, mode, harmonic, percussive, bass, duration, split_type)
-                output_ahap = os.path.join(output_dir, os.path.basename(input_wav).replace('.wav', f'_{split_type}.ahap'))
+                output_ahap = os.path.join(output_dir, os.path.basename(input_wav).replace(os.path.splitext(input_wav)[-1], f'_{split_type}.ahap'))
                 write_ahap_file(output_ahap, ahap_data)
                 output_files.append(output_ahap)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 pydub
 matplotlib
 scipy
+tqdm


### PR DESCRIPTION
FIX Object of type ‘float32’ is not JSON serializable
FIX --split bass cause dump all part of file
ADD support multi audio format like mp3 ogg etc...
ADD --split all support
ADD tqdm to requirements.txt

TEST passed by python3.9

NICE PROJECT👍🏻